### PR TITLE
Set type=module

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -1,6 +1,7 @@
 {
   "name": "<%= name %>",
   "version": "0.0.0",
+  "type": "module",
   "description": "The default blueprint for Embroider v2 addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
This enables so much for us, it's really hard to not have <3

Users of vite already support type=module v2 addons 🎉 

Blocked:
- [ ] ember-auto-import needs to support type=module in v2 addons
- [ ] embroider3-webpack needs to support type=module in v2 addons