### PR TITLE
Add support for WRITE_FIXTURES=true when working with fixture-tests

### DIFF
--- a/tests/helpers/assertions.ts
+++ b/tests/helpers/assertions.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import fse from 'fs-extra';
 import { expect } from 'vitest';
 
-import { readFixture } from './fixtures.js';
+import { readFixture, writeFixture } from './fixtures.js';
 import { packageJsonAt } from './utils.js';
 
 interface AssertGeneratedOptions {
@@ -162,6 +162,12 @@ export async function matchesFixture(
   }
 
   let sourceContents = (await fs.readFile(testFilePath)).toString();
+
+  if (process.env.WRITE_FIXTURES) {
+    console.info(`Writing fixture: ${fixtureFile} in  scenario: ${scenario}`);
+    await writeFixture(fixtureFile, sourceContents, { scenario });
+  }
+
   let fixtureContents = await readFixture(fixtureFile, { scenario });
 
   /**

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -44,6 +44,25 @@ export async function readFixture(
   return contents.toString();
 }
 
+export async function writeFixture(
+  /**
+   * Which file within in the fixture-set / scenario to read
+   */
+  file: string, 
+  contents: string,
+  options?: { 
+    /**
+     * Which fixture set to use
+     */
+  scenario?: string }) {
+
+
+  let scenario = options?.scenario ?? 'default';
+  let fixtureFilePath = path.isAbsolute(file) ? file : path.join(fixturesPath, scenario, file);
+
+  await fs.writeFile(fixtureFilePath, contents);
+}
+
 export async function copyFixture(
   /**
    * Which file within the fixture-set / scenario to copy


### PR DESCRIPTION
Extracted from: https://github.com/ember-cli/ember-addon-blueprint/pull/41