### PR TITLE
Add package.json#imports

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -80,6 +80,9 @@
     "type": "addon",
     "main": "addon-main.cjs"
   },
+  "imports": {
+    "#src/*": "./src/*"
+  },
   "exports": {<% if (typescript) { %>
     ".": {
       "types": "./declarations/index.d.ts",

--- a/tests/fixtures/rendering-tests/template-import-test.gjs
+++ b/tests/fixtures/rendering-tests/template-import-test.gjs
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import TemplateImport from "my-addon/components/template-import";
+import TemplateImport from "#src/components/template-import";
 
 module('Rendering | template-import', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Taken from
- https://github.com/ember-cli/ember-addon-blueprint/pull/41


In:
- https://github.com/ember-cli/ember-addon-blueprint/issues/37

>  ensure there's a clear strategy for self-imports in tests (package.json points at dist, tests build directly against src, so node's default self-importing support will not work). Or explain that you should use subpath imports instead.

this PR explains that we should use subpath imports instead, as to use self-imports you must first build the addon, and we don't want that.


Benefits:
- easier tests (no need to `../../` or specify the whole addon name all the time)
- can alias a lot of things, even the `#helpers/*` directory in tests, which is especially useful when you have deep testing folders 