### PR TITLE
Add *essential* stalled / ending-too-soon debugging utilities.

### DIFF
--- a/files/tests/test-helper.js
+++ b/files/tests/test-helper.js
@@ -18,9 +18,27 @@ class TestApp extends EmberApp {
 Router.map(function () {});
 
 import * as QUnit from 'qunit';
-import { setApplication } from '@ember/test-helpers';
+import { setApplication, getSettledState } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
+import { getPendingWaiterState } from '@ember/test-waiters';
 import { start as qunitStart, setupEmberOnerrorValidation } from 'ember-qunit';
+
+Object.assign(window, {
+  getSettledState,
+  getPendingWaiterState,
+  snapshotTimers: (label?: string) => {
+    const result = JSON.parse(
+      JSON.stringify({
+        settled: getSettledState(),
+        waiters: getPendingWaiterState(),
+      })
+    );
+
+    console.debug(label ?? 'snapshotTimers', result);
+
+    return result;
+  },
+});
 
 export function start() {
   setApplication(


### PR DESCRIPTION
These utilities are _essential_ for debugging anything related to:
- stuck tests
- tests progressing too soon
- etc

Specifically, snapshotTimers is good because it serializer the waiter information so it doesn't change out from underneath if you if you were to just do `getPendingWaiterState()` and log that out.

Similar to: https://github.com/ember-cli/ember-app-blueprint/pull/30