### PR TITLE
fix: `testem.js` -> `testem.cjs` in `index.html`

### DIFF
--- a/files/tests/index.html
+++ b/files/tests/index.html
@@ -14,7 +14,7 @@
       </div>
     </div>
 
-    <script src="/testem.js" integrity="" data-embroider-ignore></script>
+    <script src="/testem.cjs" integrity="" data-embroider-ignore></script>
     <script type="module">
       import "ember-testing";
     </script>


### PR DESCRIPTION
I noticed errors about missing `testem.js`. the question is do we still need this reference in index.hml?