### PR TITLE
Tests should use different output directory as to not troll the library author

### DIFF
--- a/files/.prettierignore
+++ b/files/.prettierignore
@@ -3,6 +3,7 @@
 
 # compiled output
 /dist/
+/dist-*/
 /declarations/
 
 # misc

--- a/files/eslint.config.mjs
+++ b/files/eslint.config.mjs
@@ -43,7 +43,7 @@ const config = [
    * https://eslint.org/docs/latest/use/configure/ignore
    */
   {
-    ignores: ['dist/', 'declarations/', 'node_modules/', 'coverage/', '!**/.*'],
+    ignores: ['dist/', 'dist-*/', 'declarations/', 'node_modules/', 'coverage/', '!**/.*'],
   },
   /**
    * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options

--- a/files/gitignore
+++ b/files/gitignore
@@ -1,5 +1,6 @@
 # compiled output
 dist/
+dist-tests/
 declarations/
 
 # from scenarios

--- a/files/package.json
+++ b/files/package.json
@@ -25,7 +25,7 @@
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
     "lint:types": "glint",<% } %>
     "start": "vite dev",
-    "test": "vite build --mode=development && testem --file testem.cjs ci --port 0",
+    "test": "vite build --mode=development --out-dir dist-tests && testem --file testem.cjs ci --port 0",
     "prepack": "rollup --config"
   },
   "dependencies": {

--- a/files/testem.cjs
+++ b/files/testem.cjs
@@ -3,7 +3,7 @@
 if (typeof module !== 'undefined') {
   module.exports = {
     test_page: 'tests/index.html?hidepassed',
-    cwd: 'dist',
+    cwd: 'dist-tests',
     disable_watching: true,
     launch_in_ci: ['Chrome'],
     launch_in_dev: ['Chrome'],


### PR DESCRIPTION
`dist` is currently _very_ overloaded.

This could lead to things like:
- accidentally publishing the test-app to npm instead of the rollup's dist output (depends on which order you run things)
- accidentally thinking self-imports work without a `resolve.alias` config (which we do have now, but slightly beside the point)

We want it to be possible to:
- pnpm build
- pnpm test:ember
- pnpm publish

and have the correct `dist` directory be published.