### PR TITLE
Configure ember-template-lint to not check hbs literals in tests

### DIFF
--- a/files/.template-lintrc.cjs
+++ b/files/.template-lintrc.cjs
@@ -2,4 +2,5 @@
 
 module.exports = {
   extends: 'recommended',
+  checkHbsTemplateLiterals: false,
 };

--- a/files/package.json
+++ b/files/package.json
@@ -56,7 +56,7 @@
     "ember-qunit": "^9.0.2",
     "ember-resolver": "^13.1.0",
     "ember-source": "^6.3.0",
-    "ember-template-lint": "^7.7.0",
+    "ember-template-lint": "^7.9.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-ember": "^12.3.3",


### PR DESCRIPTION
..., as only gjs/gts testing is supported


Extracted from: https://github.com/ember-cli/ember-addon-blueprint/pull/55/files