### PR TITLE
Use Node v22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -86,7 +86,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -108,7 +108,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: "Generate Explanation and Prep Changelogs"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm

--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= pnpm ? 'pnpm install --frozen-lockfile' : yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
@@ -41,7 +41,7 @@ jobs:
       - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= pnpm ? 'pnpm install --frozen-lockfile' : yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>
@@ -63,7 +63,7 @@ jobs:
       - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= pnpm ? 'pnpm install --no-lockfile' : yarn ? 'yarn install --no-lockfile' : 'npm install --no-package-lock' %>
@@ -84,7 +84,7 @@ jobs:
       - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm' %>
       - name: Apply Scenario
         run: |

--- a/files/.github/workflows/push-dist.yml
+++ b/files/.github/workflows/push-dist.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v4<% } %>
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm' %>
       - name: Install Dependencies
         run: <%= pnpm ? 'pnpm install --frozen-lockfile' : yarn ? 'yarn install --frozen-lockfile' : 'npm ci' %>

--- a/tests/fixtures/default/.github/workflows/ci.yml
+++ b/tests/fixtures/default/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Install Dependencies
         run: npm install --no-package-lock
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Apply Scenario
         run: |

--- a/tests/fixtures/default/.github/workflows/push-dist.yml
+++ b/tests/fixtures/default/.github/workflows/push-dist.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -41,7 +41,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --no-lockfile
@@ -84,7 +84,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Apply Scenario
         run: |

--- a/tests/fixtures/pnpm/.github/workflows/push-dist.yml
+++ b/tests/fixtures/pnpm/.github/workflows/push-dist.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/tests/fixtures/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/yarn/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/tests/fixtures/yarn/.github/workflows/push-dist.yml
+++ b/tests/fixtures/yarn/.github/workflows/push-dist.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Seems fine to use the active LTS for all these files, and v18 is EOL.