### PR TITLE
Update Ember version in compat section in generated README file

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -4,7 +4,7 @@
 
 ## Compatibility
 
-- Ember.js v4.12 or above
+- Ember.js v6.4 or above
 - Embroider or ember-auto-import v2
 
 ## Installation

--- a/files/README.md
+++ b/files/README.md
@@ -4,7 +4,7 @@
 
 ## Compatibility
 
-- Ember.js v6.4 or above
+- Ember.js v5.8 or above
 - Embroider or ember-auto-import v2
 
 ## Installation


### PR DESCRIPTION
`v6.4` is the last supported LTS version according to https://emberjs.com/releases/lts/.