### PR TITLE
Update to stable Glint

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -23,7 +23,7 @@
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",<% if (typescript) { %>
-    "lint:types": "glint",<% } %>
+    "lint:types": "ember-tsc --noEmit",<% } %>
     "start": "vite dev",
     "test": "vite build --mode=development --out-dir dist-tests && testem --file testem.cjs ci --port 0",
     "prepack": "rollup --config"

--- a/files/package.json
+++ b/files/package.json
@@ -48,11 +48,9 @@
     "@embroider/vite": "^1.1.5",
     "@eslint/js": "^9.17.0",
     "@glimmer/component": "^2.0.0",<% if (typescript) { %>
-    "@glint/core": "^2.0.0-alpha.2",
-    "@glint/environment-ember-loose": "^2.0.0-alpha.2",
-    "@glint/environment-ember-template-imports": "^2.0.0-alpha.2",
-    "@glint/template": "^1.6.0-alpha.1",
-    "@glint/tsserver-plugin": "^2.0.0-alpha.2",<% } %>
+    "@glint/ember-tsc": "^1.0.0",
+    "@glint/template": "^1.6.0",
+    "@glint/tsserver-plugin": "^2.0.0",<% } %>
     "@rollup/plugin-babel": "^6.0.4",<% if (typescript) { %>
     "@types/qunit": "^2.19.12",<% } %>
     "babel-plugin-ember-template-compilation": "^2.2.5",

--- a/files/rollup.config.mjs
+++ b/files/rollup.config.mjs
@@ -64,8 +64,8 @@ export default {
     addon.declarations(
       'declarations',
       <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,<% } else if (npm) 
-                   { %>`npm exec ember-tsc --declaration --project ${tsConfig}`,<% } else 
-                   { %>`npx @glint/ember-tsc --declaration --project ${tsConfig}`,<% } %>
+                   { %>`npm exec ember-tsc -- --declaration --project ${tsConfig}`,<% } else 
+                   { %>`npx @glint/ember-tsc -- --declaration --project ${tsConfig}`,<% } %>
     ),<% } %>
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/files/rollup.config.mjs
+++ b/files/rollup.config.mjs
@@ -63,9 +63,9 @@ export default {
     // Emit .d.ts declaration files
     addon.declarations(
       'declarations',
-      <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,
-      <% } else if (npm) { %>`npm exec ember-tsc --declaration --project ${tsconfig}`,
-      <% } else { %>`npx @glint/ember-tsc --declaration --project ${tsconfig}`,<% } %>
+      <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,<% } else if (npm) 
+                   { %>`npm exec ember-tsc --declaration --project ${tsconfig}`,<% } else 
+                   { %>`npx @glint/ember-tsc --declaration --project ${tsconfig}`,<% } %>
     ),<% } %>
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/files/rollup.config.mjs
+++ b/files/rollup.config.mjs
@@ -64,8 +64,8 @@ export default {
     addon.declarations(
       'declarations',
       <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,<% } else if (npm) 
-                   { %>`npm exec ember-tsc --declaration --project ${tsconfig}`,<% } else 
-                   { %>`npx @glint/ember-tsc --declaration --project ${tsconfig}`,<% } %>
+                   { %>`npm exec ember-tsc --declaration --project ${tsConfig}`,<% } else 
+                   { %>`npx @glint/ember-tsc --declaration --project ${tsConfig}`,<% } %>
     ),<% } %>
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/files/rollup.config.mjs
+++ b/files/rollup.config.mjs
@@ -63,7 +63,9 @@ export default {
     // Emit .d.ts declaration files
     addon.declarations(
       'declarations',
-      `npx glint --declaration --project ${tsConfig}`,
+      <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,
+      <% } else if (npm) { %>`npm exec ember-tsc --declaration --project ${tsconfig}`,
+      <% } else { %>`npx @glint/ember-tsc --declaration --project ${tsconfig}`,<% } %>
     ),<% } %>
 
     // addons are allowed to contain imports of .css files, which we want rollup

--- a/files/tsconfig.json
+++ b/files/tsconfig.json
@@ -11,6 +11,6 @@
   "include": ["src/**/*", "tests/**/*", "unpublished-development-types/**/*"],
   "compilerOptions": {
     "rootDir": ".",
-    "types": ["ember-source/types", "vite/client", "@embroider/core/virtual"]
+    "types": ["ember-source/types", "vite/client", "@embroider/core/virtual", "@glint/ember-tsc/types"]
   }
 }

--- a/files/tsconfig.json
+++ b/files/tsconfig.json
@@ -11,6 +11,11 @@
   "include": ["src/**/*", "tests/**/*", "unpublished-development-types/**/*"],
   "compilerOptions": {
     "rootDir": ".",
-    "types": ["ember-source/types", "vite/client", "@embroider/core/virtual", "@glint/ember-tsc/types"]
+    "types": [
+      "ember-source/types",
+      "vite/client",
+      "@embroider/core/virtual",
+      "@glint/ember-tsc/types"
+    ]
   }
 }

--- a/files/tsconfig.publish.json
+++ b/files/tsconfig.publish.json
@@ -25,6 +25,6 @@
     */
     "rootDir": "./src",
 
-    "types": ["ember-source/types"]
+    "types": ["ember-source/types", "@glint/ember-tsc/types"]
   }
 }


### PR DESCRIPTION
Upgrade Guide: https://github.com/typed-ember/glint/blob/main/docs/v2-upgrade.md