### PR TITLE
Remove extra space from package.exports default entry

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -89,7 +89,7 @@
   "exports": {
     ".": {
       "<% if (typescript) { %>types": "./declarations/index.d.ts",
-      "<% } %> default": "./dist/index.js"
+      "<% } %>default": "./dist/index.js"
     },
     "./addon-main.js": "./addon-main.cjs",
     "./*.css": "./dist/*.css",


### PR DESCRIPTION
Hi there. This is my first PR contribution on GitHub so please bear with me if I'm doing something wrong!

This PR fixes the error **[commonjs--resolver] Failed to resolve entry for package ".....". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "....." package** when importing from the addon package.

There's a leading space in `exports/./ default` that needs removing.

Currently the addon's package.json looks like this:

```json
"exports": {
    ".": {
      "types": "./declarations/index.d.ts",
      " default": "./dist/index.js"
    },
    "./addon-main.js": "./addon-main.cjs",
    "./*.css": "./dist/*.css",
    "./*": {
      "types": "./declarations/*.d.ts",
      "default": "./dist/*.js"
    }
  }
```