### PR TITLE
Change import statement to use named import for App

### DIFF
--- a/files/index.html
+++ b/files/index.html
@@ -15,7 +15,7 @@
 <body>
 
   <script type="module">
-    import App from './demo-app/app';
+    import { App } from './demo-app/app';
 
     App.create({})
   </script>


### PR DESCRIPTION
This import must match this export: 
https://github.com/ember-cli/ember-addon-blueprint/blob/2a95a64fae7e357fdb23d26d7ec722695ca10e0a/files/demo-app/app.gts#L10

Issue introduced in 
https://github.com/ember-cli/ember-addon-blueprint/pull/89


@evoactivity mentioned a thing that is probably worth mentioning reasoning behind:

A named import diverges from the main app Blueprint:

but only because the main app blueprint is beholden to previous blueprints.
I argue that:

1. an import in your app from your app should be a named import. (Otherwise why name anything at all? Named exports also help a toooon with import suggestions)
1. Leave export default for 'the framework'.


This is also base common expectations for the ecosystem for like.. 10 years, so there is a lot of precedent.