### PR TITLE
Use `cjs` extension for `ember-cli-build` file

### DIFF
--- a/files/.try.mjs
+++ b/files/.try.mjs
@@ -1,6 +1,6 @@
 // When building your addon for older Ember versions you need to have the required files
 const compatFiles = {
-  'ember-cli-build.js': `const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+  'ember-cli-build.cjs': `const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const { compatBuild } = require('@embroider/compat');
 module.exports = async function (defaults) {
   const { buildOnce } = await import('@embroider/vite');

--- a/files/gitignore
+++ b/files/gitignore
@@ -6,7 +6,7 @@ declarations/
 # from scenarios
 tmp/
 config/optional-features.json
-ember-cli-build.js
+ember-cli-build.cjs
 
 # npm/pnpm/yarn pack output
 *.tgz


### PR DESCRIPTION
This way, linting doesn't fail if you apply a scenario locally.
See: https://github.com/ember-cli/ember-addon-blueprint/blob/main/files/eslint.config.mjs#L101.