### PR TITLE
Add packageManager field to package.json

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -53,8 +53,7 @@ jobs:
         run: <%= pnpm ? 'pnpm' : yarn ? 'yarn' : 'npm run' %> test
       # For the Try Scenarios
       - id: set-matrix
-        run: |
-          <% if (pnpm) { %>echo "matrix=$(pnpm -s dlx @embroider/try list)" >> $GITHUB_OUTPUT<% } %><% if (npm) { %>echo "matrix=$(npx @embroider/try list)" >> $GITHUB_OUTPUT<% } %>
+        run: <% if (pnpm) { %>echo "matrix=$(pnpm -s dlx @embroider/try list)" >> $GITHUB_OUTPUT<% } %><% if (npm) { %>echo "matrix=$(npx @embroider/try list)" >> $GITHUB_OUTPUT<% } %>
 
   floating:
     name: "Floating Dependencies"
@@ -100,6 +99,5 @@ jobs:
       - name: Install Dependencies
         run: <%= pnpm ? 'pnpm install --no-lockfile' : yarn ? 'yarn install --no-lockfile' : 'npm install --no-package-lock' %>
       - name: Run Tests
-        run: |
-          <% if (pnpm) { %>pnpm test<% } %><% if (npm) { %>npm test<% } %>
+        run: <% if (pnpm) { %>pnpm test<% } %><% if (npm) { %>npm test<% } %>
         env: ${{ matrix.env }}

--- a/tests/fixtures/default/.github/workflows/ci.yml
+++ b/tests/fixtures/default/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
         run: npm run test
       # For the Try Scenarios
       - id: set-matrix
-        run: |
-          
-           echo "matrix=$(npx @embroider/try list)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(npx @embroider/try list)" >> $GITHUB_OUTPUT
 
   floating:
     name: "Floating Dependencies"
@@ -83,13 +81,9 @@ jobs:
           node-version: 22
           cache: npm
       - name: Apply Scenario
-        run: |
-          
-           npx @embroider/try apply ${{ matrix.name }}
+        run: npx @embroider/try apply ${{ matrix.name }}
       - name: Install Dependencies
         run: npm install --no-package-lock
       - name: Run Tests
-        run: |
-          
-          npm test
+        run: npm test
         env: ${{ matrix.env }}

--- a/tests/fixtures/pnpm/.github/workflows/ci.yml
+++ b/tests/fixtures/pnpm/.github/workflows/ci.yml
@@ -53,8 +53,7 @@ jobs:
         run: pnpm test
       # For the Try Scenarios
       - id: set-matrix
-        run: |
-          echo "matrix=$(pnpm -s dlx @embroider/try list)" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(pnpm -s dlx @embroider/try list)" >> $GITHUB_OUTPUT
 
   floating:
     name: "Floating Dependencies"
@@ -94,13 +93,10 @@ jobs:
           node-version: 22
           cache: pnpm
       - name: Apply Scenario
-        run: |
-          pnpm dlx @embroider/try apply ${{ matrix.name }}
+        run: pnpm dlx @embroider/try apply ${{ matrix.name }}
 
       - name: Install Dependencies
         run: pnpm install --no-lockfile
       - name: Run Tests
-        run: |
-          pnpm test
-
+        run: pnpm test
         env: ${{ matrix.env }}

--- a/tests/fixtures/yarn/.github/workflows/ci.yml
+++ b/tests/fixtures/yarn/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   try-scenarios:
     name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
-    needs: 'test'
+    needs: "test"
     timeout-minutes: 10
 
     strategy:


### PR DESCRIPTION
I found out in testing: #101, that pnpm/action-setup now requires the pnpm version to be set.

It's unfortunate we can't use the packageManager field.
If we had an async hook in blueprint generation (at all), we could get the latest version of npm, pnpm, whatever, and set that.

This PR also makes me feel like we should split the workflow files by packageManager, because all the conditional logic is a nightmare in the current templated files/ci.yml