### PR TITLE
Remove alias resolution from vite.config.mjs

### DIFF
--- a/files/vite.config.mjs
+++ b/files/vite.config.mjs
@@ -6,14 +6,6 @@ import { babel } from '@rollup/plugin-babel';
 const isCompat = Boolean(process.env.ENABLE_COMPAT_BUILD);
 
 export default defineConfig({
-  resolve: {
-    alias: [
-      {
-        find: '<%= name %>',
-        replacement: `${__dirname}/src`,
-      },
-    ],
-  },
   plugins: [
     ...(isCompat ? [classicEmberSupport()] : []),
     ember(),


### PR DESCRIPTION
Removed alias resolution from Vite configuration.


It's possible to hit this error:
```
[vite] (client) Pre-transform error: No matching HTML proxy module found from <project>/src/index.html?html-proxy&index=0.js
```

Also, self imports can't work anyway unless you always preserve all modules.