### PR TITLE
eslint: if projectService is used, project should be removed

### DIFF
--- a/files/eslint.config.mjs
+++ b/files/eslint.config.mjs
@@ -29,7 +29,6 @@ const esmParserOptions = {
 <% if (typescript) { %>
 const tsParserOptions = {
   projectService: true,
-  project: true,
   tsconfigRootDir: import.meta.dirname,
 };
 <% } %>


### PR DESCRIPTION
Currently you will receive a lint warning if both are used together.

Docs show to remove it when projectService is used.
https://typescript-eslint.io/blog/project-service/#configuration