### PR TITLE
Apply `typescript-eslint`'s recommended config to gts files

### DIFF
--- a/files/eslint.config.mjs
+++ b/files/eslint.config.mjs
@@ -71,7 +71,15 @@ export default defineConfig([
         ...globals.browser,
       },
     },
-    extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
+    extends: [
+      ...ts.configs.recommendedTypeChecked,
+      // https://github.com/ember-cli/ember-addon-blueprint/issues/119
+      {
+        ...ts.configs.eslintRecommended,
+        files: undefined,
+      },
+      ember.configs.gts,
+    ],
   },<% } %>
   {
     files: ['src/**/*'],

--- a/tests/fixtures/typescript/src/lint-test-gts.gts
+++ b/tests/fixtures/typescript/src/lint-test-gts.gts
@@ -1,0 +1,15 @@
+/**
+ * This file is used to ensure that `eslint.config.mjs` is properly configured
+ * to apply `typescript-eslint`'s recommended rules to `.gts` files. It ensures
+ * that:
+ *
+ * - `no-undef` is disabled (otherwise the undefined symbol would cause a
+ *   linting error)
+ * - `@typescript-eslint/no-unsafe-return` is enabled (otherwise the
+ *   `eslint-disable-next-line` comment would cause a linting error)
+ */
+export default function () {
+  // @ts-expect-error testing lint
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return notDefined;
+}

--- a/tests/fixtures/typescript/src/lint-test-ts.ts
+++ b/tests/fixtures/typescript/src/lint-test-ts.ts
@@ -1,0 +1,15 @@
+/**
+ * This file is used to ensure that `eslint.config.mjs` is properly configured
+ * to apply `typescript-eslint`'s recommended rules to `.ts` files. It ensures
+ * that:
+ *
+ * - `no-undef` is disabled (otherwise the undefined symbol would cause a
+ *   linting error)
+ * - `@typescript-eslint/no-unsafe-return` is enabled (otherwise the
+ *   `eslint-disable-next-line` comment would cause a linting error)
+ */
+export default function () {
+  // @ts-expect-error testing lint
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return notDefined;
+}

--- a/tests/smoke-tests/--typescript.test.ts
+++ b/tests/smoke-tests/--typescript.test.ts
@@ -97,6 +97,8 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
         ).toMatchInlineSnapshot(`
           [
             "src/index.ts",
+            "src/lint-test-gts.gts",
+            "src/lint-test-ts.ts",
             "src/template-registry.ts",
             "src/components/another-gts.gts",
             "src/components/template-import.gts",
@@ -111,6 +113,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
           [
             "dist/index.js",
             "dist/index.js.map",
+            "dist/lint-test-gts.js",
+            "dist/lint-test-gts.js.map",
+            "dist/lint-test-ts.js",
+            "dist/lint-test-ts.js.map",
             "dist/template-registry.js",
             "dist/template-registry.js.map",
             "dist/components/another-gts.js",
@@ -124,6 +130,10 @@ for (let packageManager of SUPPORTED_PACKAGE_MANAGERS) {
             "dist/_app_/services/example.js",
             "declarations/index.d.ts",
             "declarations/index.d.ts.map",
+            "declarations/lint-test-gts.d.ts",
+            "declarations/lint-test-gts.d.ts.map",
+            "declarations/lint-test-ts.d.ts",
+            "declarations/lint-test-ts.d.ts.map",
             "declarations/template-registry.d.ts",
             "declarations/template-registry.d.ts.map",
             "declarations/components/another-gts.d.ts",


### PR DESCRIPTION
"Patch" `typescript-eslint`'s recommended config to allow us to extend it to `gts` files, and also add test cases to verify that we're applying the ruleset to both `ts` and `gts` files.

Fixes #119