### PR TITLE
Update ember-page-title dependency to version 9.0.3

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -59,7 +59,7 @@
     "ember-source": "^6.7.0",
     "ember-strict-application-resolver": "^0.1.0",
     "ember-template-lint": "^7.9.0",
-    "ember-page-title": "^8.2.0",
+    "ember-page-title": "^9.0.3",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-ember": "^12.3.3",


### PR DESCRIPTION
Removes deprecation warnings about injecting service.