### PR TITLE
Include src in published files

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -11,7 +11,8 @@
   "files": [
     "addon-main.cjs",
     "declarations",
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "rollup --config",


### PR DESCRIPTION
Default tsconfig produces declaration map files, which link to the source code. Without publishing src as well, the map files are useless.