### PR TITLE
We can support sub-path imports in built libraries

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -53,6 +53,7 @@
     "@glint/ember-tsc": "^1.0.3",
     "@glint/template": "^1.6.1",
     "@glint/tsserver-plugin": "^2.0.0<% } %>",
+    "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-babel": "^6.0.4<% if (typescript) { %>",
     "@types/qunit": "^2.19.12<% } %>",
     "babel-plugin-ember-template-compilation": "^4.0.0",

--- a/files/rollup.config.mjs
+++ b/files/rollup.config.mjs
@@ -2,6 +2,7 @@ import { babel } from '@rollup/plugin-babel';
 import { Addon } from '@embroider/addon-dev/rollup';
 import { fileURLToPath } from 'node:url';
 import { resolve, dirname } from 'node:path';
+import nodeResolve from '@rollup/plugin-node-resolve';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -63,14 +64,21 @@ export default {
     // Emit .d.ts declaration files
     addon.declarations(
       'declarations',
-      <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,<% } else if (npm) 
-                   { %>`npm exec ember-tsc -- --declaration --project ${tsConfig}`,<% } else 
+      <% if (pnpm) { %>`pnpm ember-tsc --declaration --project ${tsConfig}`,<% } else if (npm)
+                   { %>`npm exec ember-tsc -- --declaration --project ${tsConfig}`,<% } else
                    { %>`npx @glint/ember-tsc -- --declaration --project ${tsConfig}`,<% } %>
     ),<% } %>
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.
     addon.keepAssets(['**/*.css']),
+
+		// Adds support for sub-path import resolving
+    // It's important that moduleDirectories is set to an empty array,
+    // otherwise nodeResolve will attempt to enable bundling of imported dependencies
+		nodeResolve({
+			moduleDirectories: [],
+		}),
 
     // Remove leftover build artifacts when starting a new build.
     addon.clean(),


### PR DESCRIPTION
TODO: PR to `@embroider/addon-dev`, because perhaps we can abstract the config so folks don't mistakenly bundle dependencies -- we'd need to make sure that node-resolve can still be used for folks who know how to use it tho