### PR TITLE
Fix pnpm 11

### DIFF
--- a/files/pnpm-workspace.yaml
+++ b/files/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  esbuild: false
+
 # Docs: https://pnpm.io/settings
 # https://github.com/emberjs/rfcs/pull/907
 

--- a/tests/fixtures/pnpm-addon-only/pnpm-workspace.yaml
+++ b/tests/fixtures/pnpm-addon-only/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  esbuild: false
+
 # Docs: https://pnpm.io/settings
 # https://github.com/emberjs/rfcs/pull/907
 

--- a/tests/fixtures/pnpm/pnpm-workspace.yaml
+++ b/tests/fixtures/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  esbuild: false
+
 # Docs: https://pnpm.io/settings
 # https://github.com/emberjs/rfcs/pull/907
 


### PR DESCRIPTION
Fixes: https://github.com/ember-cli/ember-addon-blueprint/issues/144


pnpm 11 requires us to pre-configure which builds we want to allow/deny.

since we don't use esbuild, I've disabled it.