### PR TITLE
Use runtime mode for testing

### DIFF
--- a/files/babel.config.cjs
+++ b/files/babel.config.cjs
@@ -10,7 +10,14 @@ const {
   templateCompatSupport,
 } = require('@embroider/compat/babel');
 
-const macros = buildMacros();
+const macros = buildMacros({
+  configure(config) {
+    if (process.env.EMBER_ENV === "test") {
+      config.enableRuntimeMode();
+    }
+  },
+});
+
 
 // For scenario testing
 const isCompat = Boolean(process.env.ENABLE_COMPAT_BUILD);

--- a/files/package.json
+++ b/files/package.json
@@ -27,7 +27,7 @@
     "lint:types": "ember-tsc --noEmit<% } %>",
     "lint:publish": "<%= runScript %> build && publint run --level error",
     "start": "vite dev",
-    "test": "vite build --mode=development --out-dir dist-tests && testem --file testem.cjs ci --port 0",
+    "test": "EMBER_ENV=test vite build --mode=development --out-dir dist-tests && testem --file testem.cjs ci --port 0",
     "prepack": "rollup --config"
   },
   "dependencies": {


### PR DESCRIPTION
Copied from: 
- https://github.com/NullVoxPopuli/ember.nvp/blob/909e80ee5a6ba0775f58f5da1624f83e55f2c18e/src/bases/minimal-app/files/babel.config.js#L4
- https://github.com/NullVoxPopuli/ember.nvp/blob/909e80ee5a6ba0775f58f5da1624f83e55f2c18e/src/layers/qunit/index.js#L41


To better handle this error:
```
error during build:
[babel] tests/test-helper.ts: setTesting(true) cannot change the testing state in compile-time mode. The current global config has isTesting=false. setTesting() calls are compiled away at build time, so they cannot change the testing state. If you need to change the testing state at runtime, use runtime mode instead.
   9 |
  10 | export function start() {
> 11 |   setTesting(true);
     |   ^^^^^^^^^^^^^^^^
  12 |   setApplication(Application.create(config.APP));
  13 |   configureNrg();
  14 |

```

so, when preparing to run tests in the CLI, we need to tell babel we want either:
- isTetsing to be true, 
- or: enable runtime mode so it can be changed